### PR TITLE
Fix silent passing of invalid test status in verify_bounds

### DIFF
--- a/autobisect/bisect.py
+++ b/autobisect/bisect.py
@@ -348,7 +348,7 @@ class Bisector(object):
             return VerificationStatus.START_BUILD_FAILED
         if status == EvaluatorResult.BUILD_CRASHED and not self.find_fix:
             return VerificationStatus.START_BUILD_CRASHES
-        if status != EvaluatorResult.BUILD_CRASHED and self.find_fix:
+        if status == EvaluatorResult.BUILD_PASSED and self.find_fix:
             return VerificationStatus.FIND_FIX_START_BUILD_PASSES
 
         status = self.test_build(self.end)

--- a/autobisect/bisect.py
+++ b/autobisect/bisect.py
@@ -344,6 +344,9 @@ class Bisector(object):
         """
         LOG.info("Attempting to verify boundaries...")
         start_result = self.test_build(self.start)
+        if start_result not in EvaluatorResult:
+            raise StatusException("Invalid status supplied")
+
         if start_result == EvaluatorResult.BUILD_FAILED:
             return VerificationStatus.START_BUILD_FAILED
         if start_result == EvaluatorResult.BUILD_CRASHED and not self.find_fix:
@@ -352,6 +355,9 @@ class Bisector(object):
             return VerificationStatus.FIND_FIX_START_BUILD_PASSES
 
         end_result = self.test_build(self.end)
+        if end_result not in EvaluatorResult:
+            raise StatusException("Invalid status supplied")
+
         if end_result == EvaluatorResult.BUILD_FAILED:
             return VerificationStatus.END_BUILD_FAILED
         if end_result == EvaluatorResult.BUILD_PASSED and not self.find_fix:

--- a/autobisect/bisect.py
+++ b/autobisect/bisect.py
@@ -344,7 +344,7 @@ class Bisector(object):
         """
         LOG.info("Attempting to verify boundaries...")
         start_result = self.test_build(self.start)
-        if start_result not in EvaluatorResult:
+        if start_result not in set(EvaluatorResult):
             raise StatusException("Invalid status supplied")
 
         if start_result == EvaluatorResult.BUILD_FAILED:
@@ -355,7 +355,7 @@ class Bisector(object):
             return VerificationStatus.FIND_FIX_START_BUILD_PASSES
 
         end_result = self.test_build(self.end)
-        if end_result not in EvaluatorResult:
+        if end_result not in set(EvaluatorResult):
             raise StatusException("Invalid status supplied")
 
         if end_result == EvaluatorResult.BUILD_FAILED:

--- a/autobisect/bisect.py
+++ b/autobisect/bisect.py
@@ -120,10 +120,6 @@ class Bisector(object):
     Taskcluster Bisection Class
     """
 
-    BUILD_CRASHED = 0
-    BUILD_PASSED = 1
-    BUILD_FAILED = 2
-
     def __init__(
         self,
         evaluator,
@@ -348,19 +344,19 @@ class Bisector(object):
         """
         LOG.info("Attempting to verify boundaries...")
         status = self.test_build(self.start)
-        if status == self.BUILD_FAILED:
+        if status == EvaluatorResult.BUILD_FAILED:
             return VerificationStatus.START_BUILD_FAILED
-        if status == self.BUILD_CRASHED and not self.find_fix:
+        if status == EvaluatorResult.BUILD_CRASHED and not self.find_fix:
             return VerificationStatus.START_BUILD_CRASHES
-        if status != self.BUILD_CRASHED and self.find_fix:
+        if status != EvaluatorResult.BUILD_CRASHED and self.find_fix:
             return VerificationStatus.FIND_FIX_START_BUILD_PASSES
 
         status = self.test_build(self.end)
-        if status == self.BUILD_FAILED:
+        if status == EvaluatorResult.BUILD_FAILED:
             return VerificationStatus.END_BUILD_FAILED
-        if status == self.BUILD_PASSED and not self.find_fix:
+        if status == EvaluatorResult.BUILD_PASSED and not self.find_fix:
             return VerificationStatus.END_BUILD_PASSES
-        if status == self.BUILD_CRASHED and self.find_fix:
+        if status == EvaluatorResult.BUILD_CRASHED and self.find_fix:
             return VerificationStatus.FIND_FIX_END_BUILD_CRASHES
 
         return VerificationStatus.SUCCESS

--- a/autobisect/bisect.py
+++ b/autobisect/bisect.py
@@ -343,20 +343,20 @@ class Bisector(object):
         :return: Boolean
         """
         LOG.info("Attempting to verify boundaries...")
-        status = self.test_build(self.start)
-        if status == EvaluatorResult.BUILD_FAILED:
+        start_result = self.test_build(self.start)
+        if start_result == EvaluatorResult.BUILD_FAILED:
             return VerificationStatus.START_BUILD_FAILED
-        if status == EvaluatorResult.BUILD_CRASHED and not self.find_fix:
+        if start_result == EvaluatorResult.BUILD_CRASHED and not self.find_fix:
             return VerificationStatus.START_BUILD_CRASHES
-        if status == EvaluatorResult.BUILD_PASSED and self.find_fix:
+        if start_result == EvaluatorResult.BUILD_PASSED and self.find_fix:
             return VerificationStatus.FIND_FIX_START_BUILD_PASSES
 
-        status = self.test_build(self.end)
-        if status == EvaluatorResult.BUILD_FAILED:
+        end_result = self.test_build(self.end)
+        if end_result == EvaluatorResult.BUILD_FAILED:
             return VerificationStatus.END_BUILD_FAILED
-        if status == EvaluatorResult.BUILD_PASSED and not self.find_fix:
+        if end_result == EvaluatorResult.BUILD_PASSED and not self.find_fix:
             return VerificationStatus.END_BUILD_PASSES
-        if status == EvaluatorResult.BUILD_CRASHED and self.find_fix:
+        if end_result == EvaluatorResult.BUILD_CRASHED and self.find_fix:
             return VerificationStatus.FIND_FIX_END_BUILD_CRASHES
 
         return VerificationStatus.SUCCESS


### PR DESCRIPTION
Boundary verification was previously broken when we switched to EvaluatorResult for passing status.  This PR implements fixes, better status checks and tests.