### PR TITLE
Offload default pref generation to grizzly

### DIFF
--- a/autobisect/evaluators/browser/tests/test_browser.py
+++ b/autobisect/evaluators/browser/tests/test_browser.py
@@ -4,28 +4,6 @@ from autobisect.evaluators import BrowserEvaluator
 from autobisect.evaluators import EvaluatorResult
 
 
-def test_prefs_arg():
-    """
-    Test that BrowserEvaluator.prefs() returns the path supplied during init
-    """
-    browser = BrowserEvaluator("testcase.html", prefs="~/foo/bar")
-    with browser.prefs() as prefs_file:
-        assert prefs_file == "~/foo/bar"
-
-
-def test_prefs_none():
-    """
-    Test that BrowserEvaluator.prefs() returns a new prefs file
-    """
-    browser = BrowserEvaluator("testcase.html")
-    with browser.prefs() as prefs_file:
-        assert prefs_file is not None
-        assert prefs_file.endswith(".js")
-        with open(prefs_file) as f:
-            data = f.read()
-            assert data.startswith("// Generated with PrefPicker")
-
-
 def test_verify_build_status(mocker):
     """
     Test that BrowserEvaluator.verify_build() returns the correct status

--- a/poetry.lock
+++ b/poetry.lock
@@ -161,7 +161,7 @@ description = "A python module that aids in the automation of Firefox at the pro
 name = "ffpuppet"
 optional = false
 python-versions = "*"
-version = "0.7.3"
+version = "0.7.4"
 
 [package.dependencies]
 psutil = ">=4.4.0"
@@ -841,7 +841,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ddd6642db05045e6788c3402733dc7bc2a0de9d4eeff40e2832cce8397efd532"
+content-hash = "ebe21f0f75d5fcce314f7438d1418d14beeb911e7877e9613565f690a17d4cfa"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -930,8 +930,8 @@ fasteners = [
     {file = "fasteners-0.15.tar.gz", hash = "sha256:3a176da6b70df9bb88498e1a18a9e4a8579ed5b9141207762368a1017bf8f5ef"},
 ]
 ffpuppet = [
-    {file = "ffpuppet-0.7.3-py2.py3-none-any.whl", hash = "sha256:e05f585c04d8d60da7e92f5ebe7a1c11b2b40083fb6b16facd58fc1598ccdbad"},
-    {file = "ffpuppet-0.7.3.tar.gz", hash = "sha256:714dd59e4369bf155d01be982da9100d851c00a6ddede9baf96a57e45e68981d"},
+    {file = "ffpuppet-0.7.4-py2.py3-none-any.whl", hash = "sha256:7a228fa9900456d0e0fd51e090e0332fa06b6b62bd49c0bd2722569d54cf5325"},
+    {file = "ffpuppet-0.7.4.tar.gz", hash = "sha256:94ef820439362ea8be245eaf1d5957b6e17fdd01aaa4ca49eeb37e4fd9196435"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ black = "^19.10b0"
 fuzzfetch = "^1.0.1"
 grizzly-framework = "^0.9.5"
 lithium-reducer = "^0.3.3"
-prefpicker = "^1.0.4"
 python = "^3.6"
 toml = "^0.9"
 


### PR DESCRIPTION
Grizzly no implements a method for generating a default pref list when none is supplied.  This PR removes that functionality from BrowserEvaluator and offloads that function to grizzly.