### PR TITLE
Simplify argument parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.6b0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
     - id: flake8
   - repo: https://github.com/marco-c/taskcluster_yml_validator

--- a/autobisect/evaluators/js/args.py
+++ b/autobisect/evaluators/js/args.py
@@ -5,15 +5,13 @@ from ...args import BisectCommonArgs
 
 
 class JSArgs(BisectCommonArgs):
-    """
-    Argparser for JSEvaluator
-    """
+    """Arguments for the JSEvaluator"""
 
     def __init__(self, parser):
         self.parser = parser
-        super().__init__()
+        super().__init__(parser)
 
-        launcher = self.parser.add_argument_group("launcher arguments")
+        launcher = self.parser.add_argument_group("Launcher Arguments")
         launcher.add_argument("--flags", help="Runtime flags to pass to the binary")
         launcher.add_argument(
             "--detect",
@@ -22,10 +20,10 @@ class JSArgs(BisectCommonArgs):
             help="Type of failure to detect (default: %(default)s)",
         )
 
-        diff = self.parser.add_argument_group("diff arguments")
+        diff = self.parser.add_argument_group("Diff Arguments")
         diff.add_argument("--arg_1", help="Arguments to supply to the first run")
         diff.add_argument("--arg_2", help="Arguments to supply to the second run")
 
-        output = self.parser.add_argument_group("output arguments")
+        output = self.parser.add_argument_group("Output Arguments")
         output.add_argument("--match", help="String to detect in output")
         output.add_argument("--regex", help="Treat match as a regex")

--- a/autobisect/main.py
+++ b/autobisect/main.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import time
-from argparse import Action, ArgumentParser
+from argparse import ArgumentParser
 from datetime import timedelta
 
 from fuzzfetch import BuildFlags
@@ -14,15 +14,6 @@ from .bisect import BisectionResult, Bisector
 from .evaluators import BrowserArgs, BrowserEvaluator, JSArgs, JSEvaluator
 
 LOG = logging.getLogger("autobisect")
-
-
-class ExpandPath(Action):
-    """
-    Expand user and relative-paths
-    """
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, os.path.abspath(os.path.expanduser(values)))
 
 
 def console_init_logging():
@@ -43,24 +34,24 @@ def parse_args():
     Argument parser
     """
     parser = ArgumentParser(description="Firefox and Spidermonkey Bisection Tool")
-    subparsers = parser.add_subparsers(dest="target")
-    subparsers.required = True
-
-    ff_sub = BrowserArgs(subparsers.add_parser("firefox", conflict_handler="resolve"))
-    js_sub = JSArgs(subparsers.add_parser("js", conflict_handler="resolve"))
+    subparsers = parser.add_subparsers(dest="target", required=True)
+    firefox_parser = BrowserArgs(subparsers.add_parser("firefox"))
+    js_parser = JSArgs(subparsers.add_parser("js"))
 
     args = parser.parse_args()
     if args.target == "firefox":
-        ff_sub.sanity_check(args)
+        firefox_parser.sanity_check(args)
     elif args.target == "js":
-        js_sub.sanity_check(args)
+        js_parser.sanity_check(args)
 
     return args
 
 
 def main(args):
-    """
-    Autobisect main entry point
+    """Autobisect main entry point
+
+    Args:
+        args: Parsed arguments
     """
     if args.target == "firefox":
         evaluator = BrowserEvaluator(**vars(args))


### PR DESCRIPTION
MRO for multiple inheritance was causing issues when trying to combine parsers for fuzzfetch, grizzly and autobisect.  To address this, I've removed the `FetcherArgs` and `ReplayArgs` inheritance and conflict resolution in favor of static rules.